### PR TITLE
Fix runtime errors by removing `as` prop from Link

### DIFF
--- a/components/cards.tsx
+++ b/components/cards.tsx
@@ -27,8 +27,7 @@ const Cards = ({ items, basePath }: ICard) => {
           key={singleCard.slug}
         >
           <Link
-            href={`/${basePath}/[id]`}
-            as={`/${basePath}/${singleCard.slug}`}
+            href={`/${basePath}/${singleCard.slug}`}
             className="no-underline"
           >
             <div className="overflow-hidden max-h-40 mb-2">

--- a/components/notes/note.tsx
+++ b/components/notes/note.tsx
@@ -1,11 +1,11 @@
+import { IContent } from '@utils/content';
+import Link from 'next/link';
 import React from 'react';
 import { Calendar } from 'react-feather';
-import Link from 'next/link';
-import { IContent } from '@utils/content';
 
 export function Note({ date, title, slug, basePath }: IContent) {
   return (
-    <Link href={`/${basePath}/[id]`} as={`/${basePath}/${slug}`} className="cursor-pointer no-underline hover:underline">
+    <Link href={`/${basePath}/${slug}`} className="cursor-pointer no-underline hover:underline">
       <article className="flex flex-col mb-4 sm:mb-0 sm:flex-row sm:items-center">
         <time className="flex w-52 text-sm items-center">
           <span className="date-icon">

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.


### PR DESCRIPTION
Using both `href` and `as` in the `Link` component caused errors in the production build:

```
[WebServer]  ✓ Starting...
[WebServer]  ✓ Ready in 343ms
Running 1 test using 1 worker
[WebServer]  ⨯ TypeError: The "path" argument must be of type string. Received undefined
[WebServer]     at h (.next/server/chunks/984.js:1:10103)
[WebServer]     at p (.next/server/app/[contentType]/[slug]/page.js:1:6489)
[WebServer]     at f (.next/server/app/[contentType]/[slug]/page.js:1:6599) {
[WebServer]   code: 'ERR_INVALID_ARG_TYPE',
[WebServer]   digest: '1055278411'
[WebServer] }
```

This PR fixes the runtime errors during navigation in the production build by simplifying the `Link` component and removing the `as` prop. Since[ Next.js v10.0.0](https://nextjs.org/docs/app/api-reference/components/link#:~:text=v10.0.0,prop.), `href` props pointing to a dynamic route are automatically resolved, making the `as` prop redundant.

> "href props pointing to a dynamic route are automatically resolved and no longer require an as prop."

